### PR TITLE
Fix Linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXXFLAGS = -I. -std=c++11
 LDFLAGS = -lSDL2 -ldl
 
 player2d : main.cpp
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp -o $@
+	$(CXX) $(CXXFLAGS) main.cpp $(LDGLAGS) -o $@
 
 .PHONY: clean player2d
 clean :


### PR DESCRIPTION
Hello.
Just a small fix - the linker flags should come after "main.cpp", otherwise gcc complains about undefined references to SDL functions (turns out the order of flags matters).

This works:

```sh
g++ -I. -std=c++11 main.cpp -lSDL2 -ldl -c -o player2d
g++ -I. -std=c++11 -lSDL2 -ldl -c main.cpp -o player2d # also works!
```

This does not:

```sh
g++ -I. -std=c++11 -lSDL2 -ldl main.cpp -o player2d
```